### PR TITLE
Correção de Bugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodenab",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Uma biblioteca para remessa e retorno de arquivos 400 e 240 do padrão cnab",
   "main": "dist/Nodenab.js",
   "scripts": {

--- a/src/Format/Picture.js
+++ b/src/Format/Picture.js
@@ -1,149 +1,157 @@
-const moment = require('moment');
+const moment = require("moment");
 
 module.exports = class Picture {
-    static get REGEX_VALID_FORMAT() {
-        return /([X9])\((\d{0,})\)((V9)\((\d{0,})\)?)?/g;
+  static get REGEX_VALID_FORMAT() {
+    return /([X9])\((\d{0,})\)((V9)\((\d{0,})\)?)?/g;
+  }
 
+  static _validarData(value) {
+    return `${value}`.match(/^\d{4}-\d{2}-\d{2}$/) !== null;
+  }
+
+  /**
+   * Valida o formato de um campo de acordo com sua picture
+   * @param format {String} Formato do campo
+   * @return {boolean}
+   */
+  static validarFormato(format) {
+    return format.match(Picture.REGEX_VALID_FORMAT).length >= 0;
+  }
+
+  /**
+   * Retorna o tamanho do campo dado seu formato
+   * @param format {String} Formato do campo
+   * @return {number}
+   */
+  static getLength(format) {
+    let lengthMatches;
+
+    if ((lengthMatches = Picture.REGEX_VALID_FORMAT.exec(format))) {
+      return +(lengthMatches[2] || 0) + +(lengthMatches[5] || 0);
+    } else {
+      throw new Error(`O padrão (${format}) não é um formato válido`);
     }
+  }
 
-    static _validarData(value) {
-        return `${value}`.match(/^\d{4}-\d{2}-\d{2}$/) !== null;
-    }
+  /**
+   * Formata uma string para retornar somente números
+   * @param value {String} Valor para formatar
+   * @return {string}
+   */
+  static parseNumber(value) {
+    return `${value}`.replace(/[^0-9.]/g, "").replace(/^0+/g, "") || "0";
+  }
 
-    /**
-     * Valida o formato de um campo de acordo com sua picture
-     * @param format {String} Formato do campo
-     * @return {boolean}
-     */
-    static validarFormato(format) {
-        return format.match(Picture.REGEX_VALID_FORMAT).length >= 0;
-    }
+  /**
+   * Encoda um valor baseado em um formato de picture de campo
+   * @param value {*} Valor de entrada para o formato
+   * @param format {String} Formato do campo do valor de entrada
+   * @param options {Object} Opções adicionais do campo
+   * @return {*}
+   */
+  static encode(value, format, options = {}) {
+    let matches;
 
-    /**
-     * Retorna o tamanho do campo dado seu formato
-     * @param format {String} Formato do campo
-     * @return {number}
-     */
-    static getLength(format) {
-        let lengthMatches;
-
-        if (lengthMatches = Picture.REGEX_VALID_FORMAT.exec(format)) {
-            return +(lengthMatches[2] || 0) + +(lengthMatches[5] || 0);
-        } else {
-            throw new Error(`O padrão (${format}) não é um formato válido`);
-        }
-    }
-
-    /**
-     * Formata uma string para retornar somente números
-     * @param value {String} Valor para formatar
-     * @return {string}
-     */
-    static parseNumber(value) {
-        return `${value}`.replace(/[^0-9.]/g, '').replace(/^0+/g, '') || '0';
-    }
-
-    /**
-     * Encoda um valor baseado em um formato de picture de campo
-     * @param value {*} Valor de entrada para o formato
-     * @param format {String} Formato do campo do valor de entrada
-     * @param options {Object} Opções adicionais do campo
-     * @return {*}
-     */
-    static encode(value, format, options = {}) {
-        let matches;
-
-        if (matches = Picture.REGEX_VALID_FORMAT.exec(format)) {
-            if (matches[1] === 'X' && !matches[4]) {
-                return `${value}`
-                    .normalize('NFD')
-                    .replace(/[\u0300-\u036f]/g, "")
-                    .substr(0, +(matches[2] || 0))
-                    .padEnd(+(matches[2] || 0), ' ')
-                    .toUpperCase();
-            } else if (matches[1] === '9') {
-                let numericValue = value;
-                if (Picture._validarData(value)) {
-                    if (options.dateFormat) {
-                        numericValue = moment(value).format(options.dateFormat);
-                    } else {
-                        if (+(matches[2] || 0) === 8) {
-                            numericValue = moment(value).format('DDMMYYYY');
-                        }
-                        if (+(matches[2] || 0) === 6) {
-                            numericValue = moment(value).format('DDMMYY');
-                        }
-                    }
-                }
-
-                if (isNaN(+numericValue)) {
-                    throw new Error(`O valor (${numericValue}) do campo ${options.field} informado deve ser um número no formato ${format}`);
-                }
-
-                numericValue = Picture.parseNumber(numericValue);
-                let numericExpression = numericValue.split('.');
-
-                if (numericExpression[1] === undefined) {
-                    numericExpression[1] = '0';
-                }
-
-                if (matches[4] === 'V9') {
-                    let tamanhoLeft = +(matches[2] || 0);
-                    let tamanhoRigth = +(matches[5] || 0);
-                    let valorLeft = numericExpression[0].padStart(tamanhoLeft, '0');
-
-                    if (numericExpression[1].length > tamanhoRigth) {
-                        let extra = numericExpression[1].length - tamanhoRigth;
-                        let extraPow = Math.pow(10, extra);
-
-                        numericExpression[1] = `${Math.round(numericExpression[1] / extraPow)}`;
-                    }
-
-                    let valorRigth = numericExpression[1].padEnd(tamanhoRigth, '0');
-
-                    return `${valorLeft}${valorRigth}`
-                } else if (!matches[4]) {
-                    return Picture.parseNumber(numericValue).padStart(+(matches[2] || 0), '0');
-                } else {
-                    throw new Error(`O padrão (${format}) não é um formato válido`);
-                }
+    if ((matches = Picture.REGEX_VALID_FORMAT.exec(format))) {
+      if (matches[1] === "X" && !matches[4]) {
+        return `${value}`
+          .normalize("NFD")
+          .replace(/[\u0300-\u036f]/g, "")
+          .substr(0, +(matches[2] || 0))
+          .padEnd(+(matches[2] || 0), " ")
+          .toUpperCase();
+      } else if (matches[1] === "9") {
+        let numericValue = value;
+        if (Picture._validarData(value)) {
+          if (options.dateFormat) {
+            numericValue = moment(value).format(options.dateFormat);
+          } else {
+            if (+(matches[2] || 0) === 8) {
+              numericValue = moment(value).format("DDMMYYYY");
             }
-        }
-    }
-
-    /**
-     * Decoda um valor baseado em um formato de picture de campo
-     * @param value {*} Valor de entrada para o decode
-     * @param format {String} Formato do campo do valor de entrada
-     * @param options {Object} Opções adicionais do campo
-     * @return {*}
-     */
-    static decode(value, format, options = {}) {
-        let matches;
-
-        if (matches = Picture.REGEX_VALID_FORMAT.exec(format)) {
-            if (matches[1] === 'X' && !matches[4]) {
-                return value.replace(/\s{1,}$/g, '');
-            } else if (matches[1] === '9') {
-                if (matches[4] === 'V9') {
-                    let tamanhoLeft = +(matches[2] || 0);
-                    let tamanhoRigth = +(matches[5] || 0);
-                    let valorLeft = Picture.parseNumber(value.substr(0, tamanhoLeft));
-                    let valorRigth = `0.${value.substr(tamanhoLeft, tamanhoRigth)}`;
-
-                    if (+(valorRigth) > 0) {
-                        return +(valorLeft) +(valorRigth);
-                    } else {
-                        return +(Picture.parseNumber(valorLeft));
-                    }
-                } else if (!matches[4]) {
-                    return +(Picture.parseNumber(value));
-                } else {
-                    throw new Error(`O padrão (${format}) não é um formato válido`);
-                }
+            if (+(matches[2] || 0) === 6) {
+              numericValue = moment(value).format("DDMMYY");
             }
-        } else {
-            throw new Error(`O padrão (${format}) não é um formato válido`);
+          }
         }
+
+        if (isNaN(+numericValue)) {
+          throw new Error(
+            `O valor (${numericValue}) do campo ${options.field} informado deve ser um número no formato ${format}`
+          );
+        }
+
+        numericValue = Picture.parseNumber(numericValue);
+        let numericExpression = numericValue.split(".");
+
+        if (numericExpression[1] === undefined) {
+          numericExpression[1] = "0";
+        }
+
+        if (matches[4] === "V9") {
+          let tamanhoLeft = +(matches[2] || 0);
+          let tamanhoRigth = +(matches[5] || 0);
+          let valorLeft = numericExpression[0].padStart(tamanhoLeft, "0");
+
+          if (numericExpression[1].length > tamanhoRigth) {
+            let extra = numericExpression[1].length - tamanhoRigth;
+            let extraPow = Math.pow(10, extra);
+
+            numericExpression[1] = `${Math.round(
+              numericExpression[1] / extraPow
+            )}`;
+          }
+
+          let valorRigth = numericExpression[1].padEnd(tamanhoRigth, "0");
+
+          return `${valorLeft}${valorRigth}`;
+        } else if (!matches[4]) {
+          return Picture.parseNumber(numericValue).padStart(
+            +(matches[2] || 0),
+            "0"
+          );
+        } else {
+          throw new Error(`O padrão (${format}) não é um formato válido`);
+        }
+      }
     }
+  }
+
+  /**
+   * Decoda um valor baseado em um formato de picture de campo
+   * @param value {*} Valor de entrada para o decode
+   * @param format {String} Formato do campo do valor de entrada
+   * @param options {Object} Opções adicionais do campo
+   * @return {*}
+   */
+  static decode(value, format, options = {}) {
+    let matches;
+
+    if ((matches = Picture.REGEX_VALID_FORMAT.exec(format))) {
+      if (matches[1] === "X" && !matches[4]) {
+        return value.replace(/\s{1,}$/g, "");
+      } else if (matches[1] === "9") {
+        if (matches[4] === "V9") {
+          let tamanhoLeft = +(matches[2] || 0);
+          let tamanhoRigth = +(matches[5] || 0);
+          let valorLeft = Picture.parseNumber(value.substr(0, tamanhoLeft));
+          let valorRigth = Picture.parseNumber(
+            `0.${value.substr(tamanhoLeft, tamanhoRigth)}`
+          );
+
+          if (+valorRigth > 0) {
+            return +valorLeft + valorRigth;
+          } else {
+            return +Picture.parseNumber(valorLeft);
+          }
+        } else if (!matches[4]) {
+          return +Picture.parseNumber(value);
+        } else {
+          throw new Error(`O padrão (${format}) não é um formato válido`);
+        }
+      }
+    } else {
+      throw new Error(`O padrão (${format}) não é um formato válido`);
+    }
+  }
 };

--- a/src/Input/RetornoFile.js
+++ b/src/Input/RetornoFile.js
@@ -54,8 +54,7 @@ module.exports = class RetornoFile extends IntercambioBancarioRetornoFileAbstrac
     const defCodigoSegmento = { pos: [14, 14], picture: "X(1)" };
     let codigoLote = null;
     let lote = null;
-    let titulos = [];
-    let segmentos = [];
+    let segmentos = {};
     let primeiroCodigoSegmentoLayout = this._layout.getPrimeiroCodigoSegmentoRetorno();
     let ultimoCodigoSegmentoLayout = this._layout.getUltimoCodigoSegmentoRetorno();
 
@@ -86,6 +85,7 @@ module.exports = class RetornoFile extends IntercambioBancarioRetornoFileAbstrac
 
         case IntercambioBancarioRetornoFileAbstract.REGISTRO_DETALHES:
           let codigoSegmento = linha.obterValorCampo(defCodigoSegmento);
+
           let dadosSegmento = linha.getDadosSegmento(
             `segmento_${codigoSegmento.toLowerCase()}`
           );
@@ -113,15 +113,14 @@ module.exports = class RetornoFile extends IntercambioBancarioRetornoFileAbstrac
               IntercambioBancarioRetornoFileAbstract.REGISTRO_DETALHES
           ) {
             lote["detalhes"].push(segmentos);
-            segmentos = [];
+            segmentos = {};
           }
 
           break;
 
         case IntercambioBancarioRetornoFileAbstract.REGISTRO_TRAILER_LOTE:
           this._model.lotes.push(lote);
-          titulos = [];
-          segmentos = [];
+          segmentos = {};
 
           break;
       }

--- a/src/Model/Linha.js
+++ b/src/Model/Linha.js
@@ -1,49 +1,57 @@
-const Picture = require('../Format/Picture');
+const Picture = require("../Format/Picture");
 
 module.exports = class Linha {
-    constructor(linhaStr, layout, tipo = 'remessa') {
-        this.linhaStr = linhaStr;
-        this.layout = layout;
-        this.tipo = tipo.toLowerCase();
+  constructor(linhaStr, layout, tipo = "remessa") {
+    this.linhaStr = linhaStr;
+    this.layout = layout;
+    this.tipo = tipo.toLowerCase();
+  }
+
+  getDadosSegmento(segmentoKey) {
+    const layout =
+      this.tipo === "remessa"
+        ? this.layout.getRemessaLayout()
+        : this.layout.getRetornoLayout();
+
+    if (layout["detalhes"][segmentoKey] === undefined) {
+      throw new Error(
+        `Erro ao processar o seguimento ${segmentoKey}. Não foi possível identificar um layout válido para o mesmo`
+      );
     }
 
-    getDadosSegmento(segmentoKey) {
-        const layout = (this.tipo === 'remessa') ?
-            this.layout.getRemessaLayout() :
-            this.layout.getRetornoLayout();
+    const campos = layout["detalhes"][segmentoKey];
+    let dados = {};
 
-        if (layout['detalhes'][segmentoKey] === undefined) {
-            throw new Error(`Erro ao processar o segumento ${segmentoKey}. Não foi possível identificar um layout válido para o mesmo`);
-        }
+    Object.keys(campos).forEach(nome => {
+      dados[nome] = this.obterValorCampo(campos[nome]);
+    });
 
-        const campos = layout['detalhes'][segmentoKey];
-        let dados = {};
+    return dados;
+  }
 
-        Object.keys(campos).forEach((nome) => {
-           dados[nome] = this.obterValorCampo(campos[nome]);
-        });
+  obterValorCampo(definicao) {
+    let tipo;
 
-        return dados;
+    if ((tipo = Picture.REGEX_VALID_FORMAT.exec(definicao["picture"]))) {
+      const inicio = definicao["pos"][0] - 1;
+      const tamanho = Picture.getLength(definicao["picture"]);
+
+      return Picture.decode(
+        this.linhaStr.substr(inicio, tamanho),
+        definicao["picture"]
+      );
+    } else {
+      throw new Error(
+        `Erro ao obter valor de campo. O padrão (${format}) não é um formato válido`
+      );
     }
+  }
 
-    obterValorCampo(definicao) {
-        let tipo;
+  getLayout() {
+    return this.layout;
+  }
 
-        if (tipo = Picture.REGEX_VALID_FORMAT.exec(definicao['picture'])) {
-            const inicio = definicao['pos'][0] - 1;
-            const tamanho = Picture.getLength(definicao['picture']);
-
-            return Picture.decode(this.linhaStr.substr(inicio, tamanho), definicao['picture']);
-        } else {
-            throw new Error(`Erro ao obter valor de campo. O padrão (${format}) não é um formato válido`);
-        }
-    }
-
-    getLayout() {
-        return this.layout;
-    }
-
-    getTipo() {
-        return this.tipo;
-    }
+  getTipo() {
+    return this.tipo;
+  }
 };


### PR DESCRIPTION
Foi feito correção de bug no método decode de classe Format/Picture.js.
O método estava tratando de forma errada as casas decimais para alguns valores.
Ex.: o que deveria ser `(float) 2000.00` era retornado como `(int) 200000`

No commit anterior eu me confundi e fiz: `let segmentos = [];` no arquivo Input/RetornoFile.js linha 57
O correto é: `let segmentos = [];`